### PR TITLE
Allow for custom cache key function

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Create a new `DataLoader` given a batch loading function and options.
   - *cache*: Default `true`. Set to `false` to disable caching, instead
     creating a new Promise and new key in the `batchLoadFn` for every load.
 
+  - *cacheKeyFn*: A function to produce a cache key for a given load key.
+    Defaults to `key => key`. Useful to provide when JavaScript objects are keys
+    and two similarly shaped objects should be considered equivalent.
+
 ##### `load(key)`
 
 Loads a key, returning a `Promise` for the value represented by that key.

--- a/src/__tests__/dataloader-test.js
+++ b/src/__tests__/dataloader-test.js
@@ -418,6 +418,56 @@ describe('Accepts options', () => {
     );
   });
 
+  describe('Accepts object key in custom cacheKey function', () => {
+    function cacheKey(key) {
+      var result;
+      if (typeof key === 'object') {
+        result = Object.keys(key).sort().map(k => k + ':' + key[k]).join('-');
+      } else {
+        result = String(key);
+      }
+      return result;
+    }
+
+    it('Accepts objects with simple key', async () => {
+      var keyA = '1234';
+      var identityLoadCalls = [];
+      var identityLoader = new DataLoader(keys => {
+        identityLoadCalls.push(keys);
+        return Promise.resolve(keys);
+      }, { cacheKeyFn: cacheKey });
+
+      var valueA = await identityLoader.load(keyA);
+      expect(valueA).to.equal(keyA);
+    });
+
+    it('Accepts objects with different order of keys', async () => {
+      var keyA = { a: 123, b: 321 };
+      var keyB = { b: 321, a: 123 };
+
+      var identityLoadCalls = [];
+      var identityLoader = new DataLoader(keys => {
+        identityLoadCalls.push(keys);
+        return Promise.resolve(keys);
+      }, { cacheKeyFn: cacheKey });
+
+      // Fetches as expected
+
+      var [ valueA, valueB ] = await Promise.all([
+        identityLoader.load(keyA),
+        identityLoader.load(keyB),
+      ]);
+
+      expect(valueA).to.equal(keyA);
+      expect(valueB).to.equal(valueA);
+
+      expect(identityLoadCalls).to.have.length(1);
+      expect(identityLoadCalls[0]).to.have.length(1);
+      expect(identityLoadCalls[0][0]).to.equal(keyA);
+    });
+
+  });
+
 });
 
 describe('It is resilient to job queue ordering', () => {


### PR DESCRIPTION
As requested in #8 and implemented by #10, this allows an option for a custom cache key function which can be useful when objects or arrays are used as load keys, since JavaScript does not use value equality on those types.