### PR TITLE
Update disabled cache flag to clear after load

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Create a new `DataLoader` given a batch loading function and options.
 
   - *cache*: Default `true`. Set to `false` to disable caching, instead
     creating a new Promise and new key in the `batchLoadFn` for every load.
+    However, if the same key is already queued to load, it will re-use
+    the existing Promise.
 
   - *cacheKeyFn*: A function to produce a cache key for a given load key.
     Defaults to `key => key`. Useful to provide when JavaScript objects are keys

--- a/src/__tests__/dataloader-test.js
+++ b/src/__tests__/dataloader-test.js
@@ -509,6 +509,24 @@ describe('Accepts options', () => {
     );
   });
 
+  it('Still batches distinct keys when cache disabled', async () => {
+    var [ identityLoader, loadCalls ] = idLoader({ cache: false });
+
+    var [ values1, values2, values3, values4 ] = await Promise.all([
+      identityLoader.load('A'),
+      identityLoader.load('C'),
+      identityLoader.load('D'),
+      identityLoader.loadMany([ 'C', 'D', 'A', 'A', 'B' ]),
+    ]);
+
+    expect(values1).to.equal('A');
+    expect(values2).to.equal('C');
+    expect(values3).to.equal('D');
+    expect(values4).to.deep.equal([ 'C', 'D', 'A', 'A', 'B' ]);
+
+    expect(loadCalls).to.deep.equal([ [ 'A', 'C', 'D', 'B' ] ]);
+  });
+
   describe('Accepts object key in custom cacheKey function', () => {
     function cacheKey(key) {
       return Object.keys(key).sort().map(k => k + ':' + key[k]).join();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,8 @@ type Options<K, V> = {
   /**
    * Default `true`. Set to `false` to disable caching,
    * instead creating a new Promise and new key in
-   * the `batchLoadFn` for every load.
+   * the `batchLoadFn` for every load. However, if the same key is already
+   * queued to load, it will re-use the existing Promise.
    */
   cache?: boolean,
 


### PR DESCRIPTION
Related to https://github.com/facebook/dataloader/pull/46, I re-used the same test case. However, I thought it would be more reasonable to re-use the same promise until the key has actually loaded instead of clearing the entire cache every tick. This includes the benefits of batching in non-cached mode, but also comes with the benefit that any requests to a currently pending key will also use the cached promise until load.

Edit: This also avoids breaking an existing implicit promise where the cache may have manually inserted a result but #46 would clear _everything_.