### PR TITLE
Caching with TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Create a new `DataLoader` given a batch loading function and options.
   - *cacheMap*: An instance of [Map][] (or an object with a similar API) to be
     used as the underlying cache for this loader. Default `new Map()`.
 
+  - *TTL*: Default `Infinity`. Defines TTL of cacheKeys in miliseconds, cacheKey will expire
+    after this period of time from the last time it is loaded.
+
 ##### `load(key)`
 
 Loads a key, returning a `Promise` for the value represented by that key.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,6 +57,11 @@ type Options<K, V> = {
    * Default `new Map()`.
    */
   cacheMap?: CacheMap<K, Promise<V>>;
+
+  /**
+   * Default `Infinity`. Defines TTL of cached keys.
+   */
+  TTL?: number;
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,7 +59,7 @@ type Options<K, V> = {
   cacheMap?: CacheMap<K, Promise<V>>;
 
   /**
-   * Default `Infinity`. Defines TTL of cached keys.
+   * Default `Infinity`. Defines TTL of cacheKeys.
    */
   TTL?: number;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export default class DataLoader<K, V> {
     var expiresAt = this._expiresAt.get(cacheKey) || parseInt(Date.now(), 10);
     var shouldUpdateCache = Date.now() >= expiresAt;
     // If caching and there is a cache-hit, return cached Promise
-    // only if the cache is not expired
+    // only if the cacheKey is not expired
     if (shouldCache && !shouldUpdateCache) {
       var cachedPromise = this._promiseCache.get(cacheKey);
       if (cachedPromise) {
@@ -120,7 +120,7 @@ export default class DataLoader<K, V> {
       this._promiseCache.set(cacheKey, promise);
     }
 
-    // If cache has expired
+    // If cacheKey has expired, update it's ttl
     if (shouldUpdateCache) {
       this._expiresAt.set(cacheKey, Date.now() + TTL);
     }


### PR DESCRIPTION
## Summary

This PR is intended to add a TTL on cacheKeys to have an eventually-consistent caches across different app instances.

We've got several cases where we don't have to be consistent in data fetching but need to be consistent after several period of time.