### PR TITLE
Validate shape of cacheMap on initialization

### DIFF
--- a/src/__tests__/abuse-test.js
+++ b/src/__tests__/abuse-test.js
@@ -150,4 +150,18 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
   });
 
+  it('Cache should have get, set, delete, and clear methods', async () => {
+    class IncompleteMap {
+      get() {}
+    }
+
+    expect(() => {
+      var incompleteMap = new IncompleteMap();
+      var options = { cacheMap: incompleteMap };
+      new DataLoader(keys => keys, options); // eslint-disable-line no-new
+    }).to.throw(
+      'Custom cache needs to implement get, set, delete, and clear methods, ' +
+      'but missing: set, delete, clear.'
+    );
+  });
 });

--- a/src/__tests__/abuse-test.js
+++ b/src/__tests__/abuse-test.js
@@ -160,8 +160,7 @@ describe('Provides descriptive error messages for API abuse', () => {
       var options = { cacheMap: incompleteMap };
       new DataLoader(keys => keys, options); // eslint-disable-line no-new
     }).to.throw(
-      'Custom cache needs to implement get, set, delete, and clear methods, ' +
-      'but missing: set, delete, clear.'
+      'Custom cacheMap missing methods: set, delete, clear'
     );
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,23 @@ export default class DataLoader<K, V> {
     }
     this._batchLoadFn = batchLoadFn;
     this._options = options;
+    var validateCacheFormat = cache => {
+      var cacheFunctions = [ 'get', 'set', 'delete', 'clear' ];
+      var missingFunctions = cacheFunctions.map(fnName => {
+        return !cache[fnName] ? fnName : null;
+      })
+      .filter(fnName => fnName !== null);
+
+      if (missingFunctions.length > 0) {
+        throw new TypeError('Custom cache needs to implement get, set, ' +
+          'delete, and clear methods, but missing: ' +
+          `${missingFunctions.join(', ')}.` );
+      }
+      return cache;
+    };
     this._promiseCache =
-      options && options.cacheMap || (new Map(): Map<K,Promise<V>>);
+      options && options.cacheMap && validateCacheFormat(options.cacheMap) ||
+      (new Map(): Map<K,Promise<V>>);
     this._queue = [];
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -311,8 +311,7 @@ function getValidCacheMap<K, V>(options: Options<K, V>): CacheMap<K, Promise<V>>
   }
   var cacheFunctions = [ 'get', 'set', 'delete', 'clear' ];
   var missingFunctions = cacheFunctions
-    .map(fnName => typeof cacheMap[fnName] !== 'function' ? fnName : null)
-    .filter(Boolean);
+    .filter(fnName => typeof cacheMap[fnName] !== 'function');
   if (missingFunctions.length !== 0) {
     throw new TypeError(
       'Custom cacheMap missing methods: ' + missingFunctions.join(', ')

--- a/src/index.js
+++ b/src/index.js
@@ -304,7 +304,9 @@ function failedDispatch<K, V>(
   });
 }
 
-function getValidCacheMap<K, V>(options: Options<K, V>): CacheMap<K, Promise<V>> {
+function getValidCacheMap<K, V>(
+  options: Options<K, V>
+): CacheMap<K, Promise<V>> {
   var cacheMap = options && options.cacheMap;
   if (!cacheMap) {
     return new Map();

--- a/src/index.js
+++ b/src/index.js
@@ -305,7 +305,7 @@ function failedDispatch<K, V>(
 }
 
 function getValidCacheMap<K, V>(
-  options: Options<K, V>
+  options: ?Options<K, V>
 ): CacheMap<K, Promise<V>> {
   var cacheMap = options && options.cacheMap;
   if (!cacheMap) {
@@ -313,7 +313,7 @@ function getValidCacheMap<K, V>(
   }
   var cacheFunctions = [ 'get', 'set', 'delete', 'clear' ];
   var missingFunctions = cacheFunctions
-    .filter(fnName => typeof cacheMap[fnName] !== 'function');
+    .filter(fnName => cacheMap && typeof cacheMap[fnName] !== 'function');
   if (missingFunctions.length !== 0) {
     throw new TypeError(
       'Custom cacheMap missing methods: ' + missingFunctions.join(', ')


### PR DESCRIPTION
Addresses https://github.com/facebook/dataloader/issues/82

Checks to see if custom cache map has the required methods on initialization. The documentation just says it needs to be an object with a similar API to Map but the DataLoader only uses those 4 methods, so I figured it was okay to selectively check for those. 