### PR TITLE
Add BatchLoader as an adapted Ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,11 @@ Looking to get started with a specific back-end? Try the [loaders in the example
 
 ## Other implementations
 
-- [PHP](https://github.com/overblog/dataloader-php)
-- [Ruby](https://github.com/sheerun/dataloader)
+* PHP
+  * [DataLoaderPHP](https://github.com/overblog/dataloader-php)
+* Ruby
+  * [Dataloader](https://github.com/sheerun/dataloader)
+  * [BatchLoader](https://github.com/exaspark/batch-loader)
 
 ## Video Source Code Walkthrough
 


### PR DESCRIPTION
> If you port DataLoader to another language, please open an issue to include a link from this repository.

Hi,

I recently created [BatchLoader](https://github.com/exAspArk/batch-loader) – an adapted Ruby implementation of DataLoader. 

The primary difference is that BatchLoader doesn't use Promises, which are not so popular in Ruby since it doesn't have an asynchronous nature. Instead, BatchLoader uses the idea of "lazy" objects which are used in the [Ruby standard library](https://ruby-doc.org/core-2.4.1/Enumerator/Lazy.html). 

In addition to the detailed description in [README](https://github.com/exAspArk/batch-loader/blob/master/README.md), I  wrote a blog post about [batching in Ruby](https://engineering.universe.com/batching-a-powerful-way-to-solve-n-1-queries-every-rubyist-should-know-24e20c6e7b94), which also describes the gem.