### PR TITLE
Replace ES6 export with node export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export type CacheMap<K, V> = {
  * different access permissions and consider creating a new instance per
  * web request.
  */
-export default class DataLoader<K, V> {
+class DataLoader<K, V> {
   constructor(
     batchLoadFn: BatchLoadFn<K, V>,
     options?: Options<K, V>
@@ -337,3 +337,5 @@ type LoaderQueue<K, V> = Array<{
   resolve: (value: V) => void;
   reject: (error: Error) => void;
 }>;
+
+module.exports = DataLoader;


### PR DESCRIPTION
While ES6 loaders that are back-compatible with node modules will treat this the same, this improves the situation for uses or node and flow.

Fixes #85